### PR TITLE
INTYG-5675: Endpoints för att sätta och hämta inställningar.

### DIFF
--- a/web/src/main/java/se/inera/intyg/rehabstod/web/controller/api/dto/PreferenceRequest.java
+++ b/web/src/main/java/se/inera/intyg/rehabstod/web/controller/api/dto/PreferenceRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018 Inera AB (http://www.inera.se)
+ *
+ * This file is part of sklintyg (https://github.com/sklintyg).
+ *
+ * sklintyg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * sklintyg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.inera.intyg.rehabstod.web.controller.api.dto;
+
+public class PreferenceRequest {
+    private String key;
+    private String value;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "PreferenceRequest [key=" + getKey() + ", value=" + getValue() + "]";
+    }
+
+}

--- a/web/src/main/java/se/inera/intyg/rehabstod/web/controller/api/dto/PreferenceResponse.java
+++ b/web/src/main/java/se/inera/intyg/rehabstod/web/controller/api/dto/PreferenceResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2018 Inera AB (http://www.inera.se)
+ *
+ * This file is part of sklintyg (https://github.com/sklintyg).
+ *
+ * sklintyg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * sklintyg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.inera.intyg.rehabstod.web.controller.api.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PreferenceResponse {
+    private Map<String, String> preferences;
+
+    public PreferenceResponse(Map<String, String> preferences) {
+        setPreferences(preferences);
+    }
+
+    public Map<String, String> getPreferences() {
+        return preferences;
+    }
+
+    public void setPreferences(Map<String, String> preferences) {
+        this.preferences = new HashMap<>(preferences);
+    }
+
+    @Override
+    public String toString() {
+        return "PreferenceResponse [preferences=" + preferences + "]";
+    }
+}

--- a/web/src/test/java/se/inera/intyg/rehabstod/web/controller/api/UserApiControllerIT.java
+++ b/web/src/test/java/se/inera/intyg/rehabstod/web/controller/api/UserApiControllerIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import se.inera.intyg.rehabstod.auth.fake.FakeCredentials;
 import se.inera.intyg.rehabstod.web.BaseRestIntegrationTest;
 import se.inera.intyg.rehabstod.web.controller.api.dto.ChangeSelectedUnitRequest;
+import se.inera.intyg.rehabstod.web.controller.api.dto.PreferenceRequest;
 
 import java.util.Arrays;
 
@@ -124,6 +125,21 @@ public class UserApiControllerIT extends BaseRestIntegrationTest {
 
         given().contentType(ContentType.JSON).and().body(changeRequest).expect().statusCode(SERVER_ERROR).when()
                 .post(USER_API_ENDPOINT + "/andraenhet");
+    }
+
+    @Test
+    public void testSetAndGetPreferenceForUser() {
+        RestAssured.sessionId = getAuthSession(DEFAULT_LAKARE);
+        PreferenceRequest request = new PreferenceRequest();
+        request.setKey("key1");
+        request.setValue("value1");
+        given().contentType(ContentType.JSON).and().body(request).expect().statusCode(OK).when()
+        .post(USER_API_ENDPOINT + "/preferences");
+
+        given().expect().statusCode(OK).when().get(USER_API_ENDPOINT + "/preferences").
+                then().
+                body(matchesJsonSchemaInClasspath("jsonschema/rhs-user-preferences-response-schema.json")).
+                body("preferences.key1", equalTo("value1"));
     }
 
 }

--- a/web/src/test/resources/jsonschema/rhs-user-preferences-response-schema.json
+++ b/web/src/test/resources/jsonschema/rhs-user-preferences-response-schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Defines the transport model of a preference response, e.g returned by /api/user/preference",
+    "properties": {
+        "preferences": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "description": "key value map"
+            }
+        }
+    },
+    "required": [
+        "preferences"
+    ],
+    "title": "User preference transport model",
+    "type": "object",
+    "additionalProperties": false
+}


### PR DESCRIPTION
Ny REST endpoint för att sätta och hämta preferences.

För att sätta en preferens:
```
POST /api/user/preferences
{
  "key": "value"
}

```
och för at hämta alla preferences:
```
GET /api/user/preferences
{
  "preferences": {
    "key": "value"
  }
}
```
