### PR TITLE
NEW-SRS: Moved risk indicator colors to mixins/_variables.scss

### DIFF
--- a/web/src/main/webapp/app/mixins/_variables.scss
+++ b/web/src/main/webapp/app/mixins/_variables.scss
@@ -31,6 +31,11 @@ $rs-color-30: #00a9a7;
 $rs-color-31: #4890E2;
 $rs-color-32: #FBC36A;
 
+// SRS risk colors
+$srs-risk-indicator-moderate: #FFE200;
+$srs-risk-indicator-high: #FF9300;
+$srs-risk-indicator-very-high: #FF0000;
+
 $rs-max-width: 1600px;
 $default-border-radius: 5px;
 

--- a/web/src/main/webapp/components/commonDirectives/rhsRiskIndicator/rhsRiskIndicator.directive.scss
+++ b/web/src/main/webapp/components/commonDirectives/rhsRiskIndicator/rhsRiskIndicator.directive.scss
@@ -28,15 +28,15 @@ rhs-risk-indicator {
   }
 
   .rhs-srs-risk-one > .rhs-srs-risk-indicator.filled {
-    background-color: #FFE200;
+    background-color: $srs-risk-indicator-moderate;
   }
 
   .rhs-srs-risk-two > .rhs-srs-risk-indicator.filled {
-    background-color: #FF9300;
+    background-color: $srs-risk-indicator-high;
   }
 
   .rhs-srs-risk-three > .rhs-srs-risk-indicator.filled {
-    background-color: #FF0000;
+    background-color: $srs-risk-indicator-very-high;
   }
 
 }


### PR DESCRIPTION
Flyttade färgkoder för SRS riskindikatorer till variabler i app/mixins/_variables.scss