### PR TITLE
INTYGFV-11933: Rättar hantering av rensning av intygsuppgifter så att…

### DIFF
--- a/web/src/main/java/se/inera/intyg/rehabstod/service/sjukfall/SjukfallServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/rehabstod/service/sjukfall/SjukfallServiceImpl.java
@@ -241,7 +241,9 @@ public class SjukfallServiceImpl implements SjukfallService {
 
         LOG.debug("Mapping response from calculation engine to internal objects.");
         List<SjukfallEnhet> rehabstodSjukfall = sjukfallList.stream()
-                .map(o -> sjukfallEngineMapper.map(o, parameters.getMaxAntalDagarSedanSjukfallAvslut(), parameters.getAktivtDatum()))
+                .map(o -> sjukfallEngineMapper.mapToSjukfallEnhetDto(o,
+                        parameters.getMaxAntalDagarSedanSjukfallAvslut(),
+                        parameters.getAktivtDatum()))
                 .collect(Collectors.toList());
 
         if (urval.equals(Urval.ISSUED_BY_ME)) {
@@ -347,7 +349,7 @@ public class SjukfallServiceImpl implements SjukfallService {
 
         LOG.debug("Mapping response from calculation engine to internal objects.");
         List<SjukfallPatient> rehabstodSjukfall = sjukfallList.stream()
-                .map(o -> sjukfallEngineMapper.map(o, vardgivareId, enhetsId))
+                .map(o -> sjukfallEngineMapper.mapToSjukfallPatientDto(o, intygAccessMetaData))
                 .collect(Collectors.toList());
 
         return new FilteredSjukFallByPatientResult(rehabstodSjukfall, sjfMetaData);

--- a/web/src/test/java/se/inera/intyg/rehabstod/service/sjukfall/SjukfallServiceTest.java
+++ b/web/src/test/java/se/inera/intyg/rehabstod/service/sjukfall/SjukfallServiceTest.java
@@ -851,7 +851,7 @@ public class SjukfallServiceTest {
         private final String patinetNamn = "Tolvan Tolvansson";
 
         @Override
-        public SjukfallEnhet map(se.inera.intyg.infra.sjukfall.dto.SjukfallEnhet from, int maxDagarSedanAvslut, LocalDate today) {
+        public SjukfallEnhet mapToSjukfallEnhetDto(se.inera.intyg.infra.sjukfall.dto.SjukfallEnhet from, int maxDagarSedanAvslut, LocalDate today) {
             se.inera.intyg.infra.sjukfall.dto.Vardgivare vardgivare =
                 new se.inera.intyg.infra.sjukfall.dto.Vardgivare(vardgivareId, vardgivareNamn);
 
@@ -866,17 +866,17 @@ public class SjukfallServiceTest {
             from.setPatient(patient);
             from.setDiagnosKod(diagnosKod);
 
-            return super.map(from, maxDagarSedanAvslut, today);
+            return super.mapToSjukfallEnhetDto(from, maxDagarSedanAvslut, today);
         }
 
         @Override
-        public SjukfallPatient map(se.inera.intyg.infra.sjukfall.dto.SjukfallPatient from, String vgId, String enhetId) {
-            return super.map(from, vgId, enhetId);
+        public SjukfallPatient mapToSjukfallPatientDto(se.inera.intyg.infra.sjukfall.dto.SjukfallPatient from, Map<String, IntygAccessControlMetaData> intygAccessMetaData) {
+            return super.mapToSjukfallPatientDto(from, intygAccessMetaData);
         }
 
         @Override
-        public PatientData map(se.inera.intyg.infra.sjukfall.dto.SjukfallIntyg from) {
-            return super.map(from);
+        public PatientData mapSjukfallIntygToPatientData(se.inera.intyg.infra.sjukfall.dto.SjukfallIntyg from, IntygAccessControlMetaData iacm) {
+            return super.mapSjukfallIntygToPatientData(from, iacm);
         }
 
         @Override


### PR DESCRIPTION
… intyg på mottagningar (underenheter) inte felaktigt behandlas som om dom vore sjf inhämtade.