### PR TITLE
INTYGFV-13612: Added a red dashed underline on enddate of expired ag-certificates. Also handled time claculation because of a failed test.

### DIFF
--- a/web/src/main/webapp/components/commonDirectives/rhsDayInRehabChain/rhsDayInRehabChain.directive.js
+++ b/web/src/main/webapp/components/commonDirectives/rhsDayInRehabChain/rhsDayInRehabChain.directive.js
@@ -35,15 +35,11 @@ angular.module('rehabstodApp').directive('rhsDayInRehabChain', ['moment', functi
           var started = moment($scope.items[0].sjukfall.start);
           var duration = moment.duration(moment().diff(started));
           var years = duration.years();
-          var durationMinusWholeYears = duration.subtract(years, 'y');
-          var days = Math.floor(durationMinusWholeYears.asDays());
+          var days = Math.floor(moment.duration(moment().diff(started.add(years,'y'))).asDays());
 
           return ((years > 0) ? years + ' år ' : '') + days + ' dagar';
-
         }
-
       };
-
     }
   };
 }]);

--- a/web/src/main/webapp/components/commonDirectives/rhsDayInRehabChain/rhsDayInRehabChain.directive.js
+++ b/web/src/main/webapp/components/commonDirectives/rhsDayInRehabChain/rhsDayInRehabChain.directive.js
@@ -35,11 +35,15 @@ angular.module('rehabstodApp').directive('rhsDayInRehabChain', ['moment', functi
           var started = moment($scope.items[0].sjukfall.start);
           var duration = moment.duration(moment().diff(started));
           var years = duration.years();
-          var days = Math.floor(moment.duration(moment().diff(started.add(years,'y'))).asDays());
+          var durationMinusWholeYears = duration.subtract(years, 'y');
+          var days = Math.floor(durationMinusWholeYears.asDays());
 
           return ((years > 0) ? years + ' år ' : '') + days + ' dagar';
+
         }
+
       };
+
     }
   };
 }]);

--- a/web/src/main/webapp/components/commonDirectives/rhsPatientAgTable/rhsPatientAgTable.directive.html
+++ b/web/src/main/webapp/components/commonDirectives/rhsPatientAgTable/rhsPatientAgTable.directive.html
@@ -60,7 +60,8 @@
                     </div>
                   </div>
                   <div data-ng-if="column.id === 'startdate'" class="nowrap">{{::intyg.start}}</div>
-                  <div data-ng-if="column.id === 'enddate'" class="nowrap">{{::intyg.end}}</div>
+                  <div data-ng-class="{'expired-certificate-end-date': isExpiredCertificate(intyg.end)}"
+                       data-ng-if="column.id === 'enddate'" class="nowrap">{{::intyg.end}}</div>
                   <div data-ng-if="column.id === 'length'">{{::intyg.days}} dagar</div>
                   <div data-ng-if="column.id === 'grade'" class="nowrap">
                     <span ng-bind-html="::formatGrader({gradArr: intyg.degree})"></span>

--- a/web/src/main/webapp/components/commonDirectives/rhsPatientAgTable/rhsPatientAgTable.directive.scss
+++ b/web/src/main/webapp/components/commonDirectives/rhsPatientAgTable/rhsPatientAgTable.directive.scss
@@ -74,7 +74,11 @@ rhs-patient-ag-table {
       }
 
       .expired-certificate {
-        font-style: italic;
+        @extend %rs-typo-13;
+      }
+
+      .expired-certificate-end-date {
+        @extend %rs-typo-14;
       }
 
       .column-number {


### PR DESCRIPTION
Leap years in "Uppskattat antal dagar i sjukfallet" have been looked at because of a failing test. The old solution first calculated the diff between startdate and todays date and then subtracted the number of years (if any), before making days(). This added som unpredictability since an interspersed leap year always got included in the resulting number of days. The new solution first adds the number of years (if any) to the startdate and then calculates the diff to todays date, then making days(). In this way the number of days exceeding full years will always be calculated on the days leading up to todays date. If this year is a leap year and the 29th of Feb have passed the extra day will thus be included. I think this is perhaps a better solution. (And it passes the tests).

However one question remains. Should the first day of a sjukfall be included in the calculation, that is if sjukfallet starts today, should this be day 1, or should tomorrow be day 1. The specs are not clear on this. The new solution counts tomorrow (according to the above) as day 1, since that is how the ols solution worked, and obviously the tests as well. Any input here?

(And got the wrong jira number on on one of the commits).